### PR TITLE
Update x-pm-appversion header to Web_3.7.2

### DIFF
--- a/src/ConversationFetcher.js
+++ b/src/ConversationFetcher.js
@@ -13,7 +13,7 @@ export default class ConversationsFetcher {
         this._headers = {
             cookie,
             'x-pm-apiversion': '1',
-            'x-pm-appversion': 'Web_3.5.12',
+            'x-pm-appversion': 'Web_3.7.2',
             'x-pm-session': sessionId
         }
         this._privateKey = privateKey;


### PR DESCRIPTION
I kept getting the following error when trying to use 'protonmail-export':

> Fetching conversations for label 0...
> TypeError: Cannot read property 'reduce' of undefined
>     at ConversationsFetcher._callee2$ (/usr/local/lib/node_modules/protonmail-export/dist/ConversationFetcher.js:111:69)
>     at tryCatch (/usr/local/lib/node_modules/protonmail-export/node_modules/babel-polyfill/node_modules/regenerator-runtime/runtime.js:63:40)
>     at Generator.invoke [as _invoke] (/usr/local/lib/node_modules/protonmail-export/node_modules/babel-polyfill/node_modules/regenerator-runtime/runtime.js:337:22)
>     at Generator.prototype.(anonymous function) [as next] (/usr/local/lib/node_modules/protonmail-export/node_modules/babel-polyfill/node_modules/regenerator-runtime/runtime.js:96:21)
>     at step (/usr/local/lib/node_modules/protonmail-export/dist/ConversationFetcher.js:27:191)
>     at /usr/local/lib/node_modules/protonmail-export/dist/ConversationFetcher.js:27:361
>     at process._tickCallback (internal/process/next_tick.js:103:7)
> 

After extensive testing / investigation I realised the 'x-pm-appversion' header was set differently in the protonmail-export code to the current version displayed in the headers on Protonmails website.

Correcting this line your code has resolved my issue and allowed me to utilise protonmail-export. You might want to merge this into your code for other people who have the same problem. :)