### PR TITLE
Updated x-pm-appversion to Web_3.11.7.

### DIFF
--- a/src/ConversationFetcher.js
+++ b/src/ConversationFetcher.js
@@ -13,7 +13,7 @@ export default class ConversationsFetcher {
         this._headers = {
             cookie,
             'x-pm-apiversion': '1',
-            'x-pm-appversion': 'Web_3.7.2',
+            'x-pm-appversion': 'Web_3.11.7',
             'x-pm-session': sessionId
         }
         this._privateKey = privateKey;


### PR DESCRIPTION
Otherwise ProtonMail throws an error even though the code is still
working.

Fixes #7 and #9.